### PR TITLE
Correct includes value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=Allows to set individual pins and takes care of shifting out the bytes
 category=Device Control
 url=https://shiftregister.simsso.de/
 architectures=*
-includes=Arduino.h
+includes=ShiftRegister74HC595.h


### PR DESCRIPTION
The includes field in library.properties is used to specify which #include directives should be added to the sketch via Sketch > Include Library > ShiftRegister74HC595. This field should specify the primary header file(s) of the library. Therefore, the value should be changed from Arduino.h to ShiftRegister74HC595.h. There is no need to #include Arduino.h in the sketch because the Arduino IDE automatically does this.