### PR TITLE
Documentation link adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ShiftRegister 74HC595 Arduino Library
 
-This library simplifies shift registers usage. It allows, for instance, to set shift register pins just like normal Arduino pins: 
+This library simplifies the usage of shift registers. For instance, it allows to set pins of the shift register just like normal Arduino pins: 
 ```
 sr.set(1, HIGH)
 ```
 
-Please find the **documentation** at https://timodenk.com/blog/shift-register-arduino-library/.
+Please find the detailed **documentation** at https://timodenk.com/blog/shift-register-arduino-library/.
 
 An **example** sketch can be found in this repository at [/examples/example/example.ino](https://github.com/Simsso/ShiftRegister74HC595/blob/master/examples/example/example.ino).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # ShiftRegister 74HC595 Arduino Library
-This library simplifies shift registers usage. It allows, for instance, to set shift register pins just like normal Arduino pins: `sr.set(1, HIGH)`.
 
-The **documentation** is available at http://shiftregister.simsso.de/.
+This library simplifies shift registers usage. It allows, for instance, to set shift register pins just like normal Arduino pins: 
+```
+sr.set(1, HIGH)
+```
+
+Please find the **documentation** at https://timodenk.com/blog/shift-register-arduino-library/.
 
 An **example** sketch can be found in this repository at [/examples/example/example.ino](https://github.com/Simsso/ShiftRegister74HC595/blob/master/examples/example/example.ino).

--- a/examples/example/example.ino
+++ b/examples/example/example.ino
@@ -1,7 +1,7 @@
 /*
   ShiftRegister74HC595 - Library for simplified control of 74HC595 shift registers.
-  Created by Timo Denk (www.timodenk.com), Nov 2014.
-  Additional information is available at http://shiftregister.simsso.de/
+  Developed and maintained by Timo Denk and contributers, since Nov 2014.
+  Additional information is available at https://timodenk.com/blog/shift-register-arduino-library/
   Released into the public domain.
 */
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,9 +1,10 @@
 ShiftRegister74HC595	KEYWORD1
 setAll	KEYWORD2
+setAll_P	KEYWORD2
+getAll	KEYWORD2
 set	KEYWORD2
+setNoUpdate	KEYWORD2
+updateRegisters	KEYWORD2
 setAllLow	KEYWORD2
 setAllHigh	KEYWORD2
 get	KEYWORD2
-getAll	KEYWORD2
-setNoUpdate	KEYWORD2
-updateRegisters	KEYWORD2

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ShiftRegister74HC595
-version=1.2
+version=1.3.1
 author=Timo Denk (timodenk.com)
 maintainer=Timo Denk (timodenk.com)
 sentence=Simplifies usage of shift registers, designed for the 74HC595.

--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=Timo Denk (timodenk.com)
 sentence=Simplifies usage of shift registers, designed for the 74HC595.
 paragraph=Allows to set individual pins and takes care of shifting out the bytes. Can be used in combination with multiple shift registers which are stacked in serial.
 category=Device Control
-url=https://shiftregister.simsso.de/
+url=hhttps://timodenk.com/blog/shift-register-arduino-library/
 architectures=*
 includes=ShiftRegister74HC595.h

--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=Timo Denk (timodenk.com)
 sentence=Simplifies usage of shift registers, designed for the 74HC595.
 paragraph=Allows to set individual pins and takes care of shifting out the bytes. Can be used in combination with multiple shift registers which are stacked in serial.
 category=Device Control
-url=hhttps://timodenk.com/blog/shift-register-arduino-library/
+url=https://timodenk.com/blog/shift-register-arduino-library/
 architectures=*
 includes=ShiftRegister74HC595.h

--- a/src/ShiftRegister74HC595.cpp
+++ b/src/ShiftRegister74HC595.cpp
@@ -1,10 +1,10 @@
 /*
   ShiftRegister74HC595.cpp - Library for simplified control of 74HC595 shift registers.
-  Created by Timo Denk (www.timodenk.com), Nov 2014.
-  Additional information is available at http://shiftregister.simsso.de/
+  Developed and maintained by Timo Denk and contributers, since Nov 2014.
+  Additional information is available at https://timodenk.com/blog/shift-register-arduino-library/
   Released into the public domain.
+*/
 */
 
 #include <Arduino.h>
-
 #include "ShiftRegister74HC595.h"

--- a/src/ShiftRegister74HC595.cpp
+++ b/src/ShiftRegister74HC595.cpp
@@ -4,7 +4,6 @@
   Additional information is available at https://timodenk.com/blog/shift-register-arduino-library/
   Released into the public domain.
 */
-*/
 
 #include <Arduino.h>
 #include "ShiftRegister74HC595.h"

--- a/src/ShiftRegister74HC595.h
+++ b/src/ShiftRegister74HC595.h
@@ -1,7 +1,7 @@
 /*
   ShiftRegister74HC595.h - Library for simplified control of 74HC595 shift registers.
-  Created by Timo Denk (www.timodenk.com), Nov 2014.
-  Additional information is available at http://shiftregister.simsso.de/
+  Developed and maintained by Timo Denk and contributers, since Nov 2014.
+  Additional information is available at https://timodenk.com/blog/shift-register-arduino-library/
   Released into the public domain.
 */
 

--- a/src/ShiftRegister74HC595.hpp
+++ b/src/ShiftRegister74HC595.hpp
@@ -1,11 +1,12 @@
 /*
   ShiftRegister74HC595.hpp - Library for simplified control of 74HC595 shift registers.
-  Created by Timo Denk (www.timodenk.com), Nov 2014.
-  Additional information is available at http://shiftregister.simsso.de/
+  Developed and maintained by Timo Denk and contributers, since Nov 2014.
+  Additional information is available at https://timodenk.com/blog/shift-register-arduino-library/
   Released into the public domain.
 */
 
 // ShiftRegister74HC595 constructor
+// Size is the number of shiftregisters stacked in serial
 template<uint8_t Size>
 ShiftRegister74HC595<Size>::ShiftRegister74HC595(const uint8_t serialDataPin, const uint8_t clockPin, const uint8_t latchPin)
 {
@@ -71,7 +72,7 @@ void ShiftRegister74HC595<Size>::set(const uint8_t pin, const uint8_t value)
 }
 
 // Updates the shift register pins to the stored output values.
-// This is the function that actually writes data into the shift registers of the 74HC595
+// This is the function that actually writes data into the shift registers of the 74HC595.
 template<uint8_t Size>
 void ShiftRegister74HC595<Size>::updateRegisters()
 {


### PR DESCRIPTION
Update the documentation page from https://shiftregister.simsso.de/ to https://timodenk.com/blog/shift-register-arduino-library/. 

The new pages has a comment feature and can be updated more easily.