### PR TITLE
2-wires mode

### DIFF
--- a/src/ShiftRegister74HC595.cpp
+++ b/src/ShiftRegister74HC595.cpp
@@ -92,9 +92,10 @@ void ShiftRegister74HC595::updateRegisters()
     for (int i = _numberOfShiftRegisters - 1; i >= 0; i--) {
         shiftOut(_serialDataPin, _clockPin, MSBFIRST, _digitalValues[i]);
     }
-    
-    digitalWrite(_latchPin, HIGH); 
-    digitalWrite(_latchPin, LOW); 
+    if (_latchPin != _clockPin) {
+        digitalWrite(_latchPin, HIGH); 
+        digitalWrite(_latchPin, LOW);
+    }
 }
 
 


### PR DESCRIPTION
Clock and latch pin may coincide. In this case there is no need to update the shift registers manually by toggling the latch pin because they will already be updated during every single bit shift. Thanks for spotting this "2-wires mode", @alf45tar.