### PR TITLE
Improvement of setNoUpdate and get functions

### DIFF
--- a/src/ShiftRegister74HC595.hpp
+++ b/src/ShiftRegister74HC595.hpp
@@ -89,7 +89,7 @@ void ShiftRegister74HC595<Size>::updateRegisters()
 template<uint8_t Size>
 void ShiftRegister74HC595<Size>::setNoUpdate(const uint8_t pin, const uint8_t value)
 {
-    (value) ? bitSet(_digitalValues[pin / 8], pin % 8) : bitClear(_digitalValues[pin / 8], pin % 8);
+    bitWrite(*_digitalValues, pin, value);
 }
 
 // Returns the state of the given pin.
@@ -97,7 +97,7 @@ void ShiftRegister74HC595<Size>::setNoUpdate(const uint8_t pin, const uint8_t va
 template<uint8_t Size>
 uint8_t ShiftRegister74HC595<Size>::get(const uint8_t pin)
 {
-    return (_digitalValues[pin / 8] >> (pin % 8)) & 1;
+    return bitRead(*_digitalValues, pin);
 }
 
 // Sets all pins of all shift registers to HIGH (1).


### PR DESCRIPTION
Everytime setNoUpdate is called, it calculates quite a bit, so using pointers seems much faster.